### PR TITLE
Pull Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 [Bb]in/
 [Oo]bj/
 
+# KSP Dll's
+Assembly-CSharp.dll
+UnityEngine.dll
+
 # mstest test results
 TestResults
 

--- a/GHud/GHud.cs
+++ b/GHud/GHud.cs
@@ -31,12 +31,14 @@ public class MonoBehaviour
 
 namespace GHud
 {
-    [KSPAddon(KSPAddon.Startup.EveryScene, false)]
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
     public class GHud : MonoBehaviour
     {
         List<Device> devices = new List<Device>();  
         
         //private static string appPath = KSPUtil.ApplicationRootPath.Replace("\\", "/") + "GameData/";
+
+		public static GHud GHudmain;
 
         public bool test_mode = false;
         
@@ -127,6 +129,10 @@ namespace GHud
 
         public void Awake()
         {
+			if (GHudmain != null) return;
+			GHudmain = this;
+			UnityEngine.Object.DontDestroyOnLoad(GHudmain);
+
             if (!lcd_initialized)
             {
                 DMcLgLCD.LcdInit();
@@ -191,17 +197,23 @@ namespace GHud
             float update_delta = 1.0f;
             
 #if !TEST
-            if (!HighLogic.LoadedSceneIsFlight)
-                return;
+            //if (!HighLogic.LoadedSceneIsFlight)
+                //return;
            
             update_delta = Time.time - last_update;
              
-            if (update_delta < 0.2f)
+            if (update_delta < 0.07f)
             {
                 return;
             }
             Vessel vessel = FlightGlobals.ActiveVessel;
-            if (vessel.rigidbody == null) return;
+			if (vessel == null) {
+				foreach (Device dev in devices) {
+					dev.ClearLCD("Waiting for Flight...");
+					dev.DisplayFrame();
+				}
+				return;
+			}
 #endif
             foreach (Device dev in devices)
             {
@@ -227,11 +239,11 @@ namespace GHud
                         orbit = vessel.orbit;
                         name = vessel.GetName();
                     }
-                    if (orbit != null)
-                    {
-                        dmod.SetOrbit(orbit, name);
-                        dmod.Render(new Rectangle(0, 0, 0, 0));
-                    }
+					if (orbit != null)
+					{
+						dmod.SetOrbit(orbit, name);
+						dmod.Render(new Rectangle(0, 0, 0, 0));
+					}
 #endif
                     if (test_mode)
                     {

--- a/GHud/GHud.csproj
+++ b/GHud/GHud.csproj
@@ -76,7 +76,7 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>copy $(ProjectDir)\assemblies\DMcLgLCD.dll  $(ProjectDir)\..\testGhud\$(OutDir)</PreBuildEvent>
+    <PreBuildEvent>copy "$(ProjectDir)\assemblies\DMcLgLCD.dll"  "$(ProjectDir)\..\testGhud\$(OutDir)"</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GHud/GHud.csproj
+++ b/GHud/GHud.csproj
@@ -36,13 +36,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\KSPFiles\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\KSPFiles\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GHud/GHud.csproj
+++ b/GHud/GHud.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;TEST</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/GHud/Properties/AssemblyInfo.cs
+++ b/GHud/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.1")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/KSPFiles/KSP DLL's Here.txt
+++ b/KSPFiles/KSP DLL's Here.txt
@@ -1,0 +1,1 @@
+Copy the files Assembly-CSharp.dll and UnityEngine.dll located in {KSP_Root}\KSP_Data\Managed\ into this folder

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 GHud
-====
+=========================
 
 Plugin for Kerbal Space Program (KSP) which adds displays to Logitech G series keyboards.  G19, G510 etc.
+
+
+For Development
+=========================
+
+Make sure to put the files Assembly-CSharp.dll and UnityEngine.dll located in {KSP_Root}\KSP_Data\Managed\
+into the KSPFiles folder. this will allow you to build straight away no matter what version of VS or hopefully
+IDE's you want to use. the "testGHud" project in the solution is to test GHud without running KSP, it needs to
+have the build mode set to "Debug" (As far as I know) and most likely a good idea to uncomment the #define TEST.
+If you want to compile for use with KSP make sure to select the "Release" Profile else it will not compile
+in a way that KSP can use

--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@ For Development
 =========================
 
 Make sure to put the files Assembly-CSharp.dll and UnityEngine.dll located in {KSP_Root}\KSP_Data\Managed\
-into the KSPFiles folder. this will allow you to build straight away no matter what version of VS or hopefully
-IDE's you want to use. the "testGHud" project in the solution is to test GHud without running KSP, it needs to
-have the build mode set to "Debug" (As far as I know) and most likely a good idea to uncomment the #define TEST.
-If you want to compile for use with KSP make sure to select the "Release" Profile else it will not compile
-in a way that KSP can use
+into the KSPFiles folder. this will allow you to build straight away no matter what version of VS (or hopefully any other
+IDE's you want to use). the "testGHud" project in the solution is to test GHud without running KSP, it needs to
+have the build mode set to "Debug" (As far as I know) and also for the #define TEST at the top to be uncommented.
+If you want to compile for use with KSP make sure to select the "Release" Profile or the "Debug" Profile with the
+#define TEST commented out else it wont produce a dll that KSP can use.
+
+Dev Tips
+------------
+to have a better dev enviroment and to speed up testing I suggest going to TriggerAU's wonderful blog post
+[An Adventure in Plugin Coding - 3. A Fast Dev Enviroment... I hope](http://forum.kerbalspaceprogram.com/entries/1253-An-Adventure-in-Plugin-Coding-3-A-Fast-Dev-Environment-I-hope)
+He shows how to make KSP load quickly and automate the testing process (i.e. copy all files into KSP, start KSP and
+autoload into a save and ship).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Make sure to put the files Assembly-CSharp.dll and UnityEngine.dll located in {K
 into the KSPFiles folder. this will allow you to build straight away no matter what version of VS (or hopefully any other
 IDE's you want to use). the "testGHud" project in the solution is to test GHud without running KSP, it needs to
 have the build mode set to "Debug" (As far as I know) and also for the #define TEST at the top to be uncommented.
-If you want to compile for use with KSP make sure to select the "Release" Profile or the "Debug" Profile with the
-#define TEST commented out else it wont produce a dll that KSP can use.
+If you want to compile for use with KSP make sure to select the "Release" Profile or the "Debug" Profile with
+the #define TEST commented out else it wont produce a dll that KSP can use.
 
 Dev Tips
 ------------

--- a/testGHud/testGHud.csproj
+++ b/testGHud/testGHud.csproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\KSPFiles\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="GHud">
       <HintPath>..\GHud\bin\Debug\GHud.dll</HintPath>
@@ -59,7 +59,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\KSPFiles\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This contains a fix to make the plugin only initialize itself once and also a little bit of code
to make it show a screen when there is no active vessel. there is also code to hopefully
fix the LCD applet from being onscreen indefinitely when KSP crashes, reason why it isn't merged is talked about bellow.

Not sure how much of this you want.

the assembly/file version has also been changed to 1.2.1/1.2.1.1 (1.2.1.1 for the crash fix, though it should be 1.2.1 or 1.2.2) not that it makes much of a difference

You might want to check through it and make sure it is all good.
Also might want to definitely look through the readme and most likely edit it.

One other thing, there are 2 other branches that you might want to check.
They are autobuilder and crashfix
Autobuilder is almost all just build events to make testing and packaging releases faster (for me anyway, you might like to do it differently). I made it mainly for myself.
A bit more (verbose) info is in the autobuilder.md file.

crashfix contains code to hopefully fix the LCD applet being left onscreen after a crash, the plugin just needs to be run again and it should automatically clean it up hopefully. it isn't in the master branch as i'm not sure whether you want untested code in the plugin.
